### PR TITLE
Added missing guild role fields

### DIFF
--- a/src/Color-Chan.Discord.Core/Common/API/Converters/DiscordGuildRoleTagsDataConverter.cs
+++ b/src/Color-Chan.Discord.Core/Common/API/Converters/DiscordGuildRoleTagsDataConverter.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Color_Chan.Discord.Core.Common.API.DataModels.Guild;
+using Color_Chan.Discord.Core.Exceptions;
+
+namespace Color_Chan.Discord.Core.Common.API.Converters;
+
+/// <summary>
+///     Enables us to have a decent domain model for <see cref="DiscordGuildRoleTagsData" />.
+///     I hate discord so much for implementing this in such a dump way....
+///     Why is boolean true when the json property exists, and false when it doesn't?
+///     They better have a good reason for this (:
+/// </summary>
+public class DiscordGuildRoleTagsDataConverter : JsonConverter<DiscordGuildRoleTagsData>
+{
+    /// <inheritdoc />
+    public override DiscordGuildRoleTagsData? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (reader.TokenType != JsonTokenType.StartObject)
+        {
+            throw new JsonException("Expected start of object.");
+        }
+
+        var tagsData = new DiscordGuildRoleTagsData();
+
+        while (reader.Read() && reader.TokenType != JsonTokenType.EndObject)
+        {
+            if (reader.TokenType != JsonTokenType.PropertyName)
+            {
+                throw new JsonException("Expected property name.");
+            }
+
+            var propertyName = reader.GetString();
+            reader.Read();
+
+            switch (propertyName)
+            {
+                case "bot_id":
+                    tagsData.BotId = new Uint64Converter().Read(ref reader, typeof(ulong), options);
+                    break;
+                case "integration_id":
+                    tagsData.IntegrationId = new Uint64Converter().Read(ref reader, typeof(ulong), options);
+                    break;
+                case "premium_subscriber":
+                    tagsData.PremiumSubscriber = true;
+                    break;
+                case "subscription_listing_id":
+                    tagsData.SubscriptionListingId = new Uint64Converter().Read(ref reader, typeof(ulong), options);
+                    break;
+                case "available_for_purchase":
+                    tagsData.AvailableForPurchase = true;
+                    break;
+                case "guild_connections":
+                    tagsData.GuildConnections = true;
+                    break;
+                default:
+                    throw new JsonException($"Unknown property: {propertyName}");
+            }
+        }
+
+        return tagsData;
+    }
+
+    /// <inheritdoc />
+    public override void Write(Utf8JsonWriter writer, DiscordGuildRoleTagsData value, JsonSerializerOptions options)
+    {
+        writer.WriteStartObject();
+
+        if (value.BotId.HasValue)
+            writer.WriteString("bot_id", value.BotId.Value.ToString());
+
+        if (value.IntegrationId.HasValue)
+            writer.WriteString("integration_id", value.IntegrationId.Value.ToString());
+
+        if (value.SubscriptionListingId.HasValue)
+            writer.WriteString("subscription_listing_id", value.SubscriptionListingId.Value.ToString());
+
+        if (value.PremiumSubscriber)
+            writer.WriteNull("premium_subscriber");
+
+        if (value.AvailableForPurchase)
+            writer.WriteNull("available_for_purchase");
+
+        if (value.GuildConnections)
+            writer.WriteNull("guild_connections");
+
+        writer.WriteEndObject();
+    }
+}

--- a/src/Color-Chan.Discord.Core/Common/API/Converters/DiscordGuildRoleTagsDataConverter.cs
+++ b/src/Color-Chan.Discord.Core/Common/API/Converters/DiscordGuildRoleTagsDataConverter.cs
@@ -23,6 +23,7 @@ public class DiscordGuildRoleTagsDataConverter : JsonConverter<DiscordGuildRoleT
 
         var tagsData = new DiscordGuildRoleTagsData();
 
+        var uint64Converter = new Uint64Converter();
         while (reader.Read() && reader.TokenType != JsonTokenType.EndObject)
         {
             if (reader.TokenType != JsonTokenType.PropertyName)
@@ -36,16 +37,16 @@ public class DiscordGuildRoleTagsDataConverter : JsonConverter<DiscordGuildRoleT
             switch (propertyName)
             {
                 case "bot_id":
-                    tagsData.BotId = new Uint64Converter().Read(ref reader, typeof(ulong), options);
+                    tagsData.BotId = uint64Converter.Read(ref reader, typeof(ulong), options);
                     break;
                 case "integration_id":
-                    tagsData.IntegrationId = new Uint64Converter().Read(ref reader, typeof(ulong), options);
+                    tagsData.IntegrationId = uint64Converter.Read(ref reader, typeof(ulong), options);
                     break;
                 case "premium_subscriber":
                     tagsData.PremiumSubscriber = true;
                     break;
                 case "subscription_listing_id":
-                    tagsData.SubscriptionListingId = new Uint64Converter().Read(ref reader, typeof(ulong), options);
+                    tagsData.SubscriptionListingId = uint64Converter.Read(ref reader, typeof(ulong), options);
                     break;
                 case "available_for_purchase":
                     tagsData.AvailableForPurchase = true;

--- a/src/Color-Chan.Discord.Core/Common/API/Converters/DiscordGuildRoleTagsDataConverter.cs
+++ b/src/Color-Chan.Discord.Core/Common/API/Converters/DiscordGuildRoleTagsDataConverter.cs
@@ -2,7 +2,6 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Color_Chan.Discord.Core.Common.API.DataModels.Guild;
-using Color_Chan.Discord.Core.Exceptions;
 
 namespace Color_Chan.Discord.Core.Common.API.Converters;
 
@@ -15,7 +14,7 @@ namespace Color_Chan.Discord.Core.Common.API.Converters;
 public class DiscordGuildRoleTagsDataConverter : JsonConverter<DiscordGuildRoleTagsData>
 {
     /// <inheritdoc />
-    public override DiscordGuildRoleTagsData? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    public override DiscordGuildRoleTagsData Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {
         if (reader.TokenType != JsonTokenType.StartObject)
         {

--- a/src/Color-Chan.Discord.Core/Common/API/Converters/DiscordGuildRoleTagsDataConverter.cs
+++ b/src/Color-Chan.Discord.Core/Common/API/Converters/DiscordGuildRoleTagsDataConverter.cs
@@ -8,7 +8,7 @@ namespace Color_Chan.Discord.Core.Common.API.Converters;
 
 /// <summary>
 ///     Enables us to have a decent domain model for <see cref="DiscordGuildRoleTagsData" />.
-///     I hate discord so much for implementing this in such a dump way....
+///     I hate discord so much for implementing this in such a dumb way....
 ///     Why is boolean true when the json property exists, and false when it doesn't?
 ///     They better have a good reason for this (:
 /// </summary>

--- a/src/Color-Chan.Discord.Core/Common/API/Converters/DiscordGuildRoleTagsDataConverter.cs
+++ b/src/Color-Chan.Discord.Core/Common/API/Converters/DiscordGuildRoleTagsDataConverter.cs
@@ -67,23 +67,12 @@ public class DiscordGuildRoleTagsDataConverter : JsonConverter<DiscordGuildRoleT
     {
         writer.WriteStartObject();
 
-        if (value.BotId.HasValue)
-            writer.WriteString("bot_id", value.BotId.Value.ToString());
-
-        if (value.IntegrationId.HasValue)
-            writer.WriteString("integration_id", value.IntegrationId.Value.ToString());
-
-        if (value.SubscriptionListingId.HasValue)
-            writer.WriteString("subscription_listing_id", value.SubscriptionListingId.Value.ToString());
-
-        if (value.PremiumSubscriber)
-            writer.WriteNull("premium_subscriber");
-
-        if (value.AvailableForPurchase)
-            writer.WriteNull("available_for_purchase");
-
-        if (value.GuildConnections)
-            writer.WriteNull("guild_connections");
+        if (value.BotId.HasValue) writer.WriteString("bot_id", value.BotId.Value.ToString());
+        if (value.IntegrationId.HasValue) writer.WriteString("integration_id", value.IntegrationId.Value.ToString());
+        if (value.SubscriptionListingId.HasValue) writer.WriteString("subscription_listing_id", value.SubscriptionListingId.Value.ToString());
+        if (value.PremiumSubscriber) writer.WriteNull("premium_subscriber");
+        if (value.AvailableForPurchase) writer.WriteNull("available_for_purchase");
+        if (value.GuildConnections) writer.WriteNull("guild_connections");
 
         writer.WriteEndObject();
     }

--- a/src/Color-Chan.Discord.Core/Common/API/DataModels/Guild/DiscordGuildRoleColorsData.cs
+++ b/src/Color-Chan.Discord.Core/Common/API/DataModels/Guild/DiscordGuildRoleColorsData.cs
@@ -7,15 +7,15 @@ namespace Color_Chan.Discord.Core.Common.API.DataModels.Guild;
 /// <inheritdoc cref="IDiscordGuildRoleColors" />
 public record DiscordGuildRoleColorsData
 {
-    /// <inheritdoc cref="IDiscordGuildRoleColors" />
+    /// <inheritdoc cref="IDiscordGuildRoleColors.Primary" />
     [JsonPropertyName("primary_color")]
     public Color Primary { get; init; }
 
-    /// <inheritdoc cref="IDiscordGuildRoleColors" />
+    /// <inheritdoc cref="IDiscordGuildRoleColors.Secondary" />
     [JsonPropertyName("secondary_color")]
     public Color? Secondary { get; init; }
 
-    /// <inheritdoc cref="IDiscordGuildRoleColors" />
+    /// <inheritdoc cref="IDiscordGuildRoleColors.Tertiary" />
     [JsonPropertyName("tertiary_color")]
     public Color? Tertiary { get; init; }
 }

--- a/src/Color-Chan.Discord.Core/Common/API/DataModels/Guild/DiscordGuildRoleColorsData.cs
+++ b/src/Color-Chan.Discord.Core/Common/API/DataModels/Guild/DiscordGuildRoleColorsData.cs
@@ -1,0 +1,21 @@
+﻿using System.Drawing;
+using System.Text.Json.Serialization;
+using Color_Chan.Discord.Core.Common.Models.Guild;
+
+namespace Color_Chan.Discord.Core.Common.API.DataModels.Guild;
+
+/// <inheritdoc cref="IDiscordGuildRoleColors" />
+public record DiscordGuildRoleColorsData
+{
+    /// <inheritdoc cref="IDiscordGuildRoleColors" />
+    [JsonPropertyName("primary_color")]
+    public Color Primary { get; init; }
+
+    /// <inheritdoc cref="IDiscordGuildRoleColors" />
+    [JsonPropertyName("secondary_color")]
+    public Color? Secondary { get; init; }
+
+    /// <inheritdoc cref="IDiscordGuildRoleColors" />
+    [JsonPropertyName("tertiary_color")]
+    public Color? Tertiary { get; init; }
+}

--- a/src/Color-Chan.Discord.Core/Common/API/DataModels/Guild/DiscordGuildRoleData.cs
+++ b/src/Color-Chan.Discord.Core/Common/API/DataModels/Guild/DiscordGuildRoleData.cs
@@ -34,8 +34,8 @@ public record DiscordGuildRoleData
     public string? Icon { get; init; }
     
     /// <inheritdoc cref="IDiscordGuildRole.UnicodeEmoji" />
+    [JsonPropertyName("unicode_emoji")]
     public string? UnicodeEmoji { get; init; }
-
     /// <inheritdoc cref="IDiscordGuildRole.Position" />
     [JsonPropertyName("position")]
     public int Position { get; init; }

--- a/src/Color-Chan.Discord.Core/Common/API/DataModels/Guild/DiscordGuildRoleData.cs
+++ b/src/Color-Chan.Discord.Core/Common/API/DataModels/Guild/DiscordGuildRoleData.cs
@@ -1,4 +1,5 @@
-﻿using System.Drawing;
+﻿using System;
+using System.Drawing;
 using System.Text.Json.Serialization;
 using Color_Chan.Discord.Core.Common.Models.Guild;
 
@@ -17,11 +18,23 @@ public record DiscordGuildRoleData
 
     /// <inheritdoc cref="IDiscordGuildRole.Color" />
     [JsonPropertyName("color")]
+    [Obsolete("Use Colors instead.")]
     public Color Color { get; init; }
+    
+    /// <inheritdoc cref="IDiscordGuildRole.Colors" />
+    [JsonPropertyName("colors")]
+    public DiscordGuildRoleColorsData Colors { get; init; } = null!;
 
     /// <inheritdoc cref="IDiscordGuildRole.IsHoisted" />
     [JsonPropertyName("hoist")]
     public bool IsHoisted { get; init; }
+    
+    /// <inheritdoc cref="IDiscordGuildRole.Icon" />
+    [JsonPropertyName("icon")]
+    public string? Icon { get; init; }
+    
+    /// <inheritdoc cref="IDiscordGuildRole.UnicodeEmoji" />
+    public string? UnicodeEmoji { get; init; }
 
     /// <inheritdoc cref="IDiscordGuildRole.Position" />
     [JsonPropertyName("position")]
@@ -38,4 +51,12 @@ public record DiscordGuildRoleData
     /// <inheritdoc cref="IDiscordGuildRole.Mentionable" />
     [JsonPropertyName("mentionable")]
     public bool Mentionable { get; init; }
+    
+    /// <inheritdoc cref="IDiscordGuildRole.Tags" />
+    [JsonPropertyName("tags")]
+    public DiscordGuildRoleTagsData? Tags { get; init; }
+    
+    /// <inheritdoc cref="IDiscordGuildRole.Flags" />
+    [JsonPropertyName("flags")]
+    public DiscordGuildRoleFlags Flags { get; init; }
 }

--- a/src/Color-Chan.Discord.Core/Common/API/DataModels/Guild/DiscordGuildRoleFlags.cs
+++ b/src/Color-Chan.Discord.Core/Common/API/DataModels/Guild/DiscordGuildRoleFlags.cs
@@ -1,0 +1,21 @@
+﻿using System;
+
+namespace Color_Chan.Discord.Core.Common.API.DataModels.Guild;
+
+/// <summary>
+///     Represents a discord Guild Role Flags API model.
+///     Docs: https://discord.com/developers/docs/topics/permissions#role-object-role-flags
+/// </summary>
+[Flags]
+public enum DiscordGuildRoleFlags
+{
+    /// <summary>
+    ///     No role flags.
+    /// </summary>
+    None = 0,
+
+    /// <summary>
+    ///     Role can be selected by members in an onboarding prompt.
+    /// </summary>
+    InPromt = 1 << 0
+}

--- a/src/Color-Chan.Discord.Core/Common/API/DataModels/Guild/DiscordGuildRoleFlags.cs
+++ b/src/Color-Chan.Discord.Core/Common/API/DataModels/Guild/DiscordGuildRoleFlags.cs
@@ -17,5 +17,5 @@ public enum DiscordGuildRoleFlags
     /// <summary>
     ///     Role can be selected by members in an onboarding prompt.
     /// </summary>
-    InPromt = 1 << 0
+    InPrompt = 1 << 0
 }

--- a/src/Color-Chan.Discord.Core/Common/API/DataModels/Guild/DiscordGuildRoleTagsData.cs
+++ b/src/Color-Chan.Discord.Core/Common/API/DataModels/Guild/DiscordGuildRoleTagsData.cs
@@ -1,0 +1,34 @@
+﻿using System.Text.Json.Serialization;
+using Color_Chan.Discord.Core.Common.API.Converters;
+using Color_Chan.Discord.Core.Common.Models.Guild;
+
+namespace Color_Chan.Discord.Core.Common.API.DataModels.Guild;
+
+/// <inheritdoc cref="IDiscordGuildRoleTags" />
+[JsonConverter(typeof(DiscordGuildRoleTagsDataConverter))]
+public class DiscordGuildRoleTagsData
+{
+    /// <inheritdoc cref="IDiscordGuildRoleTags.BotId"/>
+    [JsonPropertyName("bot_id")]
+    public ulong? BotId { get; set; }
+    
+    /// <inheritdoc cref="IDiscordGuildRoleTags.IntegrationId"/>
+    [JsonPropertyName("integration_id")]
+    public ulong? IntegrationId { get; set; }
+    
+    /// <inheritdoc cref="IDiscordGuildRoleTags.PremiumSubscriber"/>
+    [JsonPropertyName("premium_subscriber")]
+    public bool PremiumSubscriber { get; set; }
+    
+    /// <inheritdoc cref="IDiscordGuildRoleTags.SubscriptionListingId"/>
+    [JsonPropertyName("subscription_listing_id")]
+    public ulong? SubscriptionListingId { get; set; }
+    
+    /// <inheritdoc cref="IDiscordGuildRoleTags.AvailableForPurchase"/>
+    [JsonPropertyName("available_for_purchase")]
+    public bool AvailableForPurchase { get; set; }
+    
+    /// <inheritdoc cref="IDiscordGuildRoleTags.GuildConnections"/>
+    [JsonPropertyName("guild_connections")]
+    public bool GuildConnections { get; set; }
+}

--- a/src/Color-Chan.Discord.Core/Common/Models/Guild/IDiscordGuildRole.cs
+++ b/src/Color-Chan.Discord.Core/Common/Models/Guild/IDiscordGuildRole.cs
@@ -27,7 +27,9 @@ public interface IDiscordGuildRole
     [Obsolete("Use Colors instead.")]
     Color Color { get; init; }
     
-    /// <inheritdoc cref="IDiscordGuildRole.Colors" />
+    /// <summary>
+    ///     The role's colors.     
+    /// </summary>
     public IDiscordGuildRoleColors Colors { get; init; }
 
     /// <summary>

--- a/src/Color-Chan.Discord.Core/Common/Models/Guild/IDiscordGuildRole.cs
+++ b/src/Color-Chan.Discord.Core/Common/Models/Guild/IDiscordGuildRole.cs
@@ -1,4 +1,5 @@
-﻿using System.Drawing;
+﻿using System;
+using System.Drawing;
 using Color_Chan.Discord.Core.Common.API.DataModels;
 using Color_Chan.Discord.Core.Common.API.DataModels.Guild;
 
@@ -23,12 +24,26 @@ public interface IDiscordGuildRole
     /// <summary>
     ///     Integer representation of hexadecimal color code.
     /// </summary>
+    [Obsolete("Use Colors instead.")]
     Color Color { get; init; }
+    
+    /// <inheritdoc cref="IDiscordGuildRole.Colors" />
+    public IDiscordGuildRoleColors Colors { get; init; }
 
     /// <summary>
     ///     If this role is pinned in the user listing.
     /// </summary>
     bool IsHoisted { get; init; }
+    
+    /// <summary>
+    ///     Role icon hash.
+    /// </summary>
+    string? Icon { get; init; }
+    
+    /// <summary>
+    ///     Role unicode emoji.
+    /// </summary>
+    string? UnicodeEmoji { get; init; }
 
     /// <summary>
     ///     Position of this role.
@@ -49,6 +64,16 @@ public interface IDiscordGuildRole
     ///     Whether this role is mentionable
     /// </summary>
     bool Mentionable { get; init; }
+    
+    /// <summary>
+    ///     The tags this role has
+    /// </summary>
+    IDiscordGuildRoleTags? Tags { get; init; }
+    
+    /// <summary>
+    ///     Role can be selected by members in an onboarding prompt
+    /// </summary>
+    DiscordGuildRoleFlags Flags { get; init; }
 
     /// <summary>
     ///     Converts the model back to a discord data model so that it can be send to discord.

--- a/src/Color-Chan.Discord.Core/Common/Models/Guild/IDiscordGuildRoleColors.cs
+++ b/src/Color-Chan.Discord.Core/Common/Models/Guild/IDiscordGuildRoleColors.cs
@@ -1,0 +1,34 @@
+﻿using System.Drawing;
+using Color_Chan.Discord.Core.Common.API.DataModels.Guild;
+
+namespace Color_Chan.Discord.Core.Common.Models.Guild;
+
+/// <summary>
+///     Represents a discord Role Colors Structure API model.
+///     Docs: https://discord.com/developers/docs/topics/permissions#role-object-role-colors-object
+/// </summary>
+public interface IDiscordGuildRoleColors
+{
+    /// <summary>
+    ///     The primary color of the role.
+    /// </summary>
+    Color Primary { get; init; }
+
+    /// <summary>
+    ///     The secondary color for the role, this will make the role a gradient between the other provided colors
+    /// </summary>
+    Color? Secondary { get; init; }
+
+    /// <summary>
+    ///     The tertiary color for the role, this will turn the gradient into a holographic style
+    /// </summary>
+    Color? Tertiary { get; init; }
+    
+    /// <summary>
+    ///     Converts the model back to a discord data model so that it can be sent to discord.
+    /// </summary>
+    /// <returns>
+    ///     The converted <see cref="DiscordGuildRoleColorsData" /> model.
+    /// </returns>
+    DiscordGuildRoleColorsData ToDataModel();
+}

--- a/src/Color-Chan.Discord.Core/Common/Models/Guild/IDiscordGuildRoleTags.cs
+++ b/src/Color-Chan.Discord.Core/Common/Models/Guild/IDiscordGuildRoleTags.cs
@@ -1,0 +1,48 @@
+﻿using Color_Chan.Discord.Core.Common.API.DataModels.Guild;
+
+namespace Color_Chan.Discord.Core.Common.Models.Guild;
+
+/// <summary>
+///     Represents a discord Role Tags API model.
+///     Docs: https://discord.com/developers/docs/topics/permissions#role-object-role-tags-structure
+/// </summary>
+public interface IDiscordGuildRoleTags
+{
+    /// <summary>
+    ///     The id of the bot this role belongs to
+    /// </summary>
+    public ulong? BotId { get; set; }
+    
+    /// <summary>
+    ///     The id of the integration this role belongs to
+    /// </summary>
+    public ulong? IntegrationId { get; set; }
+    
+    /// <summary>
+    ///     Whether this is the guild's Booster role
+    /// </summary>
+    public bool PremiumSubscriber { get; set; }
+    
+    /// <summary>
+    ///     The id of this role's subscription sku and listing
+    /// </summary>
+    public ulong? SubscriptionListingId { get; set; }
+    
+    /// <summary>
+    ///     Whether this role is available for purchase
+    /// </summary>
+    public bool AvailableForPurchase { get; set; }
+    
+    /// <summary>
+    ///     Whether this role is a guild's linked role
+    /// </summary>
+    public bool GuildConnections { get; set; }
+    
+    /// <summary>
+    ///     Converts the model back to a discord data model so that it can be send to discord.
+    /// </summary>
+    /// <returns>
+    ///     The converted <see cref="DiscordGuildRoleTagsData" />.
+    /// </returns>
+    DiscordGuildRoleTagsData ToDataModel();
+}

--- a/src/Color-Chan.Discord.Core/Exceptions/Ulong64JsonConversionException.cs
+++ b/src/Color-Chan.Discord.Core/Exceptions/Ulong64JsonConversionException.cs
@@ -1,0 +1,8 @@
+﻿using System.Text.Json;
+
+namespace Color_Chan.Discord.Core.Exceptions;
+
+/// <summary>
+///     Thrown when a <see cref="ulong" /> value cannot be converted from a <see cref="string" /> json value.
+/// </summary>
+public class Ulong64JsonConversionException(string message) : JsonException(message);

--- a/src/Color-Chan.Discord.Rest/Models/Guild/DiscordGuildRole.cs
+++ b/src/Color-Chan.Discord.Rest/Models/Guild/DiscordGuildRole.cs
@@ -3,6 +3,8 @@ using Color_Chan.Discord.Core.Common.API.DataModels;
 using Color_Chan.Discord.Core.Common.API.DataModels.Guild;
 using Color_Chan.Discord.Core.Common.Models.Guild;
 
+#pragma warning disable CS0618 // Type or member is obsolete
+
 namespace Color_Chan.Discord.Rest.Models.Guild;
 
 /// <inheritdoc cref="IDiscordGuildRole" />
@@ -18,10 +20,30 @@ public record DiscordGuildRole : IDiscordGuildRole
         Name = data.Name;
         Color = data.Color;
         IsHoisted = data.IsHoisted;
+        Icon = data.Icon;
+        UnicodeEmoji = data.UnicodeEmoji;
         Position = data.Position;
         Permissions = data.Permissions;
         Managed = data.Managed;
         Mentionable = data.Mentionable;
+        Tags = data.Tags is not null ? new DiscordGuildRoleTags(data.Tags) : null;
+        Flags = data.Flags;
+
+        // Colors should never be null in production. But it can happen when using an older version of the API.
+        // ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
+        if (data.Colors is not null)
+        {
+            Colors = new DiscordGuildRoleColors
+            {
+                Primary = data.Colors.Primary,
+                Secondary = data.Colors.Secondary,
+                Tertiary = data.Colors.Tertiary
+            };
+        }
+        else
+        {
+            Colors = null!;
+        }
     }
 
     /// <inheritdoc />
@@ -34,7 +56,16 @@ public record DiscordGuildRole : IDiscordGuildRole
     public Color Color { get; init; }
 
     /// <inheritdoc />
+    public IDiscordGuildRoleColors Colors { get; init; }
+
+    /// <inheritdoc />
     public bool IsHoisted { get; init; }
+
+    /// <inheritdoc />
+    public string? Icon { get; init; }
+
+    /// <inheritdoc />
+    public string? UnicodeEmoji { get; init; }
 
     /// <inheritdoc />
     public int Position { get; init; }
@@ -49,18 +80,29 @@ public record DiscordGuildRole : IDiscordGuildRole
     public bool Mentionable { get; init; }
 
     /// <inheritdoc />
+    public IDiscordGuildRoleTags? Tags { get; init; }
+
+    /// <inheritdoc />
+    public DiscordGuildRoleFlags Flags { get; init; }
+
+    /// <inheritdoc />
     public DiscordGuildRoleData ToDataModel()
     {
         return new DiscordGuildRoleData
         {
             Color = Color,
+            Colors = Colors.ToDataModel(),
             Id = Id,
             Managed = Managed,
             Mentionable = Mentionable,
             Name = Name,
             Permissions = Permissions,
             Position = Position,
-            IsHoisted = IsHoisted
+            IsHoisted = IsHoisted,
+            Icon = Icon,
+            UnicodeEmoji = UnicodeEmoji,
+            Tags = Tags?.ToDataModel() ?? null,
+            Flags = Flags
         };
     }
 }

--- a/src/Color-Chan.Discord.Rest/Models/Guild/DiscordGuildRoleColors.cs
+++ b/src/Color-Chan.Discord.Rest/Models/Guild/DiscordGuildRoleColors.cs
@@ -1,0 +1,29 @@
+﻿using System.Drawing;
+using Color_Chan.Discord.Core.Common.API.DataModels.Guild;
+using Color_Chan.Discord.Core.Common.Models.Guild;
+
+namespace Color_Chan.Discord.Rest.Models.Guild;
+
+/// <inheritdoc cref="IDiscordGuildRoleColors" />
+public class DiscordGuildRoleColors : IDiscordGuildRoleColors
+{
+    /// <inheritdoc />
+    public Color Primary { get; init; }
+
+    /// <inheritdoc />
+    public Color? Secondary { get; init; }
+
+    /// <inheritdoc />
+    public Color? Tertiary { get; init; }
+
+    /// <inheritdoc />
+    public DiscordGuildRoleColorsData ToDataModel()
+    {
+        return new DiscordGuildRoleColorsData
+        {
+            Primary = Primary,
+            Secondary = Secondary,
+            Tertiary = Tertiary
+        };
+    }
+}

--- a/src/Color-Chan.Discord.Rest/Models/Guild/DiscordGuildRoleTags.cs
+++ b/src/Color-Chan.Discord.Rest/Models/Guild/DiscordGuildRoleTags.cs
@@ -1,0 +1,54 @@
+﻿using Color_Chan.Discord.Core.Common.API.DataModels.Guild;
+using Color_Chan.Discord.Core.Common.Models.Guild;
+
+namespace Color_Chan.Discord.Rest.Models.Guild;
+
+/// <inheritdoc cref="IDiscordGuildRoleTags" />
+public class DiscordGuildRoleTags : IDiscordGuildRoleTags
+{
+    /// <summary>
+    ///     Initializes a new <see cref="DiscordGuildRoleTags" />.
+    /// </summary>
+    /// <param name="dataTags">The data needed to create the <see cref="DiscordGuildRoleTags" />.</param>
+    public DiscordGuildRoleTags(DiscordGuildRoleTagsData dataTags)
+    {
+        BotId = dataTags.BotId;
+        IntegrationId = dataTags.IntegrationId;
+        PremiumSubscriber = dataTags.PremiumSubscriber;
+        SubscriptionListingId = dataTags.SubscriptionListingId;
+        AvailableForPurchase = dataTags.AvailableForPurchase;
+        GuildConnections = dataTags.GuildConnections;
+    }
+
+    /// <inheritdoc />
+    public ulong? BotId { get; set; }
+
+    /// <inheritdoc />
+    public ulong? IntegrationId { get; set; }
+
+    /// <inheritdoc />
+    public bool PremiumSubscriber { get; set; }
+
+    /// <inheritdoc />
+    public ulong? SubscriptionListingId { get; set; }
+
+    /// <inheritdoc />
+    public bool AvailableForPurchase { get; set; }
+
+    /// <inheritdoc />
+    public bool GuildConnections { get; set; }
+
+    /// <inheritdoc />
+    public DiscordGuildRoleTagsData ToDataModel()
+    {
+        return new DiscordGuildRoleTagsData
+        {
+            BotId = BotId,
+            IntegrationId = IntegrationId,
+            PremiumSubscriber = PremiumSubscriber,
+            SubscriptionListingId = SubscriptionListingId,
+            AvailableForPurchase = AvailableForPurchase,
+            GuildConnections = GuildConnections
+        };
+    }
+}

--- a/tests/Color-Chan.Discord.Commands.Tests/InteractionHandlers/SlashCommandHandlerTests.cs
+++ b/tests/Color-Chan.Discord.Commands.Tests/InteractionHandlers/SlashCommandHandlerTests.cs
@@ -169,7 +169,10 @@ public class DiscordSlashCommandHandlerTests
                                 865723094761078804, new DiscordGuildRoleData
                                 {
                                     Id = 865723094761078804,
-                                    Color = Color.Red,
+                                    Colors = new DiscordGuildRoleColorsData
+                                    {
+                                        Primary = Color.Red,
+                                    },
                                     Managed = false,
                                     Name = "red",
                                     Mentionable = true,

--- a/tests/Color-Chan.Discord.Commands.Tests/Services/Implementations/SlashCommandServiceTests.cs
+++ b/tests/Color-Chan.Discord.Commands.Tests/Services/Implementations/SlashCommandServiceTests.cs
@@ -276,7 +276,10 @@ public class SlashCommandServiceTests
                             new DiscordGuildRoleData
                             {
                                 Id = 865723094761078804,
-                                Color = Color.Red,
+                                Colors = new DiscordGuildRoleColorsData
+                                {
+                                    Primary = Color.Red,
+                                },
                                 Managed = false,
                                 Mentionable = true,
                                 Name = "red",

--- a/tests/Color-Chan.Discord.Core.Tests/TestJson/API/DataModels/DiscordGuildRoleData/DiscordGuildRoleData.json
+++ b/tests/Color-Chan.Discord.Core.Tests/TestJson/API/DataModels/DiscordGuildRoleData/DiscordGuildRoleData.json
@@ -6,5 +6,6 @@
   "position": 34,
   "permissions": "274877906943",
   "managed": true,
-  "mentionable": true
+  "mentionable": true,
+  "flags": 0
 }

--- a/tests/Color-Chan.Discord.Core.Tests/TestJson/API/DataModels/DiscordGuildRoleData/DiscordGuildRoleData2.json
+++ b/tests/Color-Chan.Discord.Core.Tests/TestJson/API/DataModels/DiscordGuildRoleData/DiscordGuildRoleData2.json
@@ -1,0 +1,15 @@
+﻿{
+  "id": "41771983423143936",
+  "name": "Role name!!",
+  "color": 3447003,
+  "colors": {
+    "primary_color": 3447003
+  },
+  "hoist": true,
+  "icon": "cf3ced8600b777c9486c6d8d84fb4327",
+  "position": 1,
+  "permissions": "66321471",
+  "managed": false,
+  "mentionable": false,
+  "flags": 0
+}

--- a/tests/Color-Chan.Discord.Core.Tests/TestJson/API/DataModels/DiscordGuildRoleData/DiscordGuildRoleData3.json
+++ b/tests/Color-Chan.Discord.Core.Tests/TestJson/API/DataModels/DiscordGuildRoleData/DiscordGuildRoleData3.json
@@ -1,0 +1,20 @@
+﻿{
+  "id": "41771983423143936",
+  "name": "Role name!!",
+  "color": 3447003,
+  "colors": {
+    "primary_color": 3447003
+  },
+  "hoist": true,
+  "icon": "cf3ced8600b777c9486c6d8d84fb4327",
+  "position": 1,
+  "permissions": "66321471",
+  "managed": false,
+  "mentionable": false,
+  "tags": {
+    "bot_id": "123456789012345678",
+    "integration_id": "987654321098765432",
+    "premium_subscriber": null
+  },
+  "flags": 0
+}

--- a/tests/Color-Chan.Discord.Core.Tests/TestJson/API/DataModels/DiscordGuildRoleData/DiscordGuildRoleData4.json
+++ b/tests/Color-Chan.Discord.Core.Tests/TestJson/API/DataModels/DiscordGuildRoleData/DiscordGuildRoleData4.json
@@ -1,0 +1,19 @@
+﻿{
+  "id": "41771983423143936",
+  "name": "Role name!!",
+  "color": 3447003,
+  "colors": {
+    "primary_color": 3447003
+  },
+  "hoist": true,
+  "icon": "cf3ced8600b777c9486c6d8d84fb4327",
+  "position": 1,
+  "permissions": "66321471",
+  "managed": false,
+  "mentionable": false,
+  "tags": {
+    "available_for_purchase": null,
+    "guild_connections": null
+  },
+  "flags": 0
+}

--- a/tests/Color-Chan.Discord.Core.Tests/TestJson/API/DataModels/DiscordGuildRoleData/DiscordGuildRoleData5.json
+++ b/tests/Color-Chan.Discord.Core.Tests/TestJson/API/DataModels/DiscordGuildRoleData/DiscordGuildRoleData5.json
@@ -1,0 +1,19 @@
+﻿{
+  "id": "41771983423143936",
+  "name": "Role name!!",
+  "color": 3447003,
+  "colors": {
+    "primary_color": 3447003
+  },
+  "hoist": true,
+  "icon": "cf3ced8600b777c9486c6d8d84fb4327",
+  "position": 1,
+  "permissions": "66321471",
+  "managed": false,
+  "mentionable": false,
+  "tags": {
+    "available_for_purchase": null,
+    "guild_connections": null
+  },
+  "flags": 1
+}

--- a/tests/Color-Chan.Discord.Core.Tests/TestJson/API/DataModels/DiscordInteractionResolvedData/DiscordInteractionCommandResolvedData2.json
+++ b/tests/Color-Chan.Discord.Core.Tests/TestJson/API/DataModels/DiscordInteractionResolvedData/DiscordInteractionCommandResolvedData2.json
@@ -8,7 +8,8 @@
       "position": 132,
       "permissions": "0",
       "managed": false,
-      "mentionable": false
+      "mentionable": false,
+      "flags": 0
     }
   }
 }


### PR DESCRIPTION
## Description
Marks `DiscordGuildRoleData.Color` as obsolote because it is now replaced by `colors`.

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
