### PR TITLE
Bugs/296 unable to set embed and content to null on discordeditchannelmessage

### DIFF
--- a/src/Color-Chan.Discord.Core/Common/API/Params/Channel/DiscordEditChannelMessage.cs
+++ b/src/Color-Chan.Discord.Core/Common/API/Params/Channel/DiscordEditChannelMessage.cs
@@ -17,6 +17,7 @@ public class DiscordEditChannelMessage
     ///     The message contents (up to 2000 characters).
     /// </summary>
     [JsonPropertyName("content")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.Never)]
     public string? Content { get; set; }
 
     // Todo: implemented file content support.
@@ -27,19 +28,20 @@ public class DiscordEditChannelMessage
     ///     Embedded rich content (up to 6000 characters).
     /// </summary>
     [JsonPropertyName("embeds")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.Never)]
     public IEnumerable<DiscordEmbedData>? Embeds { get; set; }
 
     /// <summary>
     ///     Embedded rich content.
     /// </summary>
-    [JsonPropertyName("embed ")]
+    [JsonPropertyName("embed")]
     [Obsolete("deprecated in favor of Embeds")]
     public IEnumerable<DiscordEmbedData>? Embed { get; set; }
 
     /// <summary>
-    ///     Edit the flags of a message (only SUPPRESS_EMBEDS can currently be set/unset).
+    ///     Edit the flags of a message (SUPPRESS_EMBEDS and IS_COMPONENTS_V2 only)
     /// </summary>
-    [JsonPropertyName("flags ")]
+    [JsonPropertyName("flags")]
     public DiscordMessageFlags? Flags { get; set; }
 
     /// <summary>

--- a/tests/Color-Chan.Discord.Core.Tests/Common/API/Params/Channel/DiscordEditChannelMessageTests.cs
+++ b/tests/Color-Chan.Discord.Core.Tests/Common/API/Params/Channel/DiscordEditChannelMessageTests.cs
@@ -1,0 +1,7 @@
+﻿using Color_Chan.Discord.Core.Common.API.Params.Channel;
+using NUnit.Framework;
+
+namespace Color_Chan.Discord.Core.Tests.Common.API.Params.Channel;
+
+[TestFixture]
+public class DiscordEditChannelMessageTests : JsonTestBase<DiscordEditChannelMessage>;

--- a/tests/Color-Chan.Discord.Core.Tests/TestJson/API/Params/DiscordEditChannelMessage/DiscordEditChannelMessage1.json
+++ b/tests/Color-Chan.Discord.Core.Tests/TestJson/API/Params/DiscordEditChannelMessage/DiscordEditChannelMessage1.json
@@ -1,0 +1,11 @@
+{
+  "content": null,
+  "embeds": [],
+  "flags": 32768,
+  "components": [
+    {
+      "type": 10,
+      "content": "# This is a Text Input Component"
+    }
+  ]
+}

--- a/tests/Color-Chan.Discord.Core.Tests/TestJson/API/Params/DiscordEditChannelMessage/DiscordEditChannelMessage2.json
+++ b/tests/Color-Chan.Discord.Core.Tests/TestJson/API/Params/DiscordEditChannelMessage/DiscordEditChannelMessage2.json
@@ -1,0 +1,11 @@
+{
+  "content": null,
+  "embeds": null,
+  "flags": 32768,
+  "components": [
+    {
+      "type": 10,
+      "content": "# This is a Text Input Component"
+    }
+  ]
+}

--- a/tests/Color-Chan.Discord.Core.Tests/TestJson/API/Params/DiscordEditChannelMessage/DiscordEditChannelMessage3.json
+++ b/tests/Color-Chan.Discord.Core.Tests/TestJson/API/Params/DiscordEditChannelMessage/DiscordEditChannelMessage3.json
@@ -1,0 +1,11 @@
+{
+  "content": "123",
+  "embeds": [],
+  "flags": 32768,
+  "components": [
+    {
+      "type": 10,
+      "content": "# This is a Text Input Component"
+    }
+  ]
+}


### PR DESCRIPTION
## Description
closes #296 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
